### PR TITLE
Rebuild

### DIFF
--- a/recipe/909.patch
+++ b/recipe/909.patch
@@ -1,0 +1,30 @@
+From ea92e3ca230a3ff3d464cb6816102fa157177aca Mon Sep 17 00:00:00 2001
+From: Jacek Migacz <jmigacz@redhat.com>
+Date: Fri, 17 Oct 2025 13:55:48 +0200
+Subject: [PATCH] Skip Kerberos tests on libcurl >= 8.17.0
+
+CURLOPT_KRBLEVEL and CURLOPT_KRB4LEVEL were removed in libcurl
+8.17.0 and now return CURLE_NOT_BUILT_IN.
+---
+ tests/option_constants_test.py | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tests/option_constants_test.py b/tests/option_constants_test.py
+index 1dd862c39..de1b08012 100644
+--- a/tests/option_constants_test.py
++++ b/tests/option_constants_test.py
+@@ -502,12 +502,14 @@ def test_ssl_sessionid_cache(self):
+         curl.setopt(curl.SSL_SESSIONID_CACHE, True)
+         curl.close()
+ 
++    @util.removed_in_libcurl(8, 17, 0)
+     @util.only_gssapi
+     def test_krblevel(self):
+         curl = pycurl.Curl()
+         curl.setopt(curl.KRBLEVEL, 'clear')
+         curl.close()
+ 
++    @util.removed_in_libcurl(8, 17, 0)
+     @util.only_gssapi
+     def test_krb4level(self):
+         curl = pycurl.Curl()

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9d43013002eab2fd6d0dcc671cd1e9149e2fc1c56d5e796fad94d076d6cb69ef
   patches:
-    # Skip Kerberos tests on libcurl >= 8.17.0, see https://github.com/pycurl/pycurl/pull/909
+    # Skip Kerberos tests on libcurl >= 8.17.0, see https://github.com/pycurl/pycurl/pull/909`
     - 909.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9d43013002eab2fd6d0dcc671cd1e9149e2fc1c56d5e796fad94d076d6cb69ef
+  patches:
+    # Skip Kerberos tests on libcurl >= 8.17.0, see https://github.com/pycurl/pycurl/pull/909
+    - 909.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - flask
     - flaky
     - pyflakes
-    # for tests/setup_test.py
+    # For tests/setup_test.py
     - setuptools
 
 about:


### PR DESCRIPTION
Rebuilding again because https://github.com/AnacondaRecipes/pycurl-feedstock/pull/13 failed after the PR was merged.
The package hasn't been released on PBP.

### Actions:

- Add a patch to skip Kerberos tests on `libcurl >= 8.17.0`, see the reason https://github.com/AnacondaRecipes/pycurl-feedstock/pull/13#issuecomment-3816444416 and https://github.com/pycurl/pycurl/pull/909